### PR TITLE
Pin release build go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
 
       - name: setup
         uses: actions/setup-go@v3
+        with:
+          go-version: ^1.19.4
+          check-latest: true
 
       - name: release
         if: startsWith(github.event.ref, 'refs/tags')


### PR DESCRIPTION
Fix the Go version used to build the release. Otherwise, the build will fail with go mod tidy.

https://github.com/kitsuyui/myip/actions/runs/3861073352