### PR TITLE
Revert "Update codecov/codecov-action action to v4"

### DIFF
--- a/.github/workflows/golang-test.yml
+++ b/.github/workflows/golang-test.yml
@@ -36,7 +36,7 @@ jobs:
           version: latest
           args: build --skip-validate --skip-post-hooks --skip-before --snapshot --rm-dist
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.out


### PR DESCRIPTION
Reverts kitsuyui/myip#222

v4 is currently in beta.

https://github.com/codecov/codecov-action/issues/1089

```
Unable to resolve action `codecov/codecov-action@v4`, unable to find version `v4`
```