### PR TITLE
Upload assets to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,9 @@ jobs:
           args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Upload assets
+        uses: actions/upload-artifact@v3
+        with:
+          name: myapp
+          path: myfolder/dist/*


### PR DESCRIPTION
- This process is required from the goreleaser v2
- I forgot to support this in https://github.com/kitsuyui/myip/pull/240
- This PR is to fix it
