### PR TITLE
Fix result aggregation shutdown

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,8 +7,10 @@ import (
 	"io/ioutil"
 
 	"log"
+	"net"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/docopt/docopt-go"
@@ -46,35 +48,65 @@ func pickUpFirstItemThatExceededThreshold(siprs []base.ScoredIPRetrievable, time
 	} else {
 		logger.SetOutput(ioutil.Discard)
 	}
-	c := make(chan base.ScoredIPWithMaxScore)
-	defer close(c)
+	type result struct {
+		scoredIP base.ScoredIPWithMaxScore
+		source   base.ScoredIPRetrievable
+		err      error
+	}
+	c := make(chan result, len(siprs))
+	var wg sync.WaitGroup
 	for _, sipr := range siprs {
 		sumOfWeight += sipr.Weight
+		wg.Add(1)
 		go func(sipr base.ScoredIPRetrievable) {
+			defer wg.Done()
 			sip, err := sipr.RetrieveIPWithScoring(ctx)
 			if err != nil {
 				logger.Printf("Error:%s\ttype:%s\tweight:%1.1f\t%s", err, typeName(sipr.IPRetrievable), sipr.Weight, sipr.String())
+				c <- result{source: sipr, err: err}
 				return
 			}
 			logger.Printf("IP:%s\ttype:%s\tweight:%1.1f\t%s", sip.IP.String(), typeName(sipr.IPRetrievable), sip.Score, sipr.String())
-			c <- *sip
+			c <- result{scoredIP: *sip, source: sipr}
 		}(sipr)
 	}
-	result := make(chan base.ScoredIP)
-	defer close(result)
 	go func() {
-		for sip := range c {
-			key := sip.IP.String()
-			m[key] += sip.Score
-			sumOfWeight -= (sip.MaxScore - sip.Score)
-			currentScore := m[key] / sumOfWeight
+		wg.Wait()
+		close(c)
+	}()
+	winner := func() (*base.ScoredIP, bool) {
+		if sumOfWeight <= 0 {
+			return nil, false
+		}
+		for ip, score := range m {
+			currentScore := score / sumOfWeight
 			if currentScore > threshold {
-				result <- base.ScoredIP{IP: sip.IP, Score: currentScore}
+				return &base.ScoredIP{IP: net.ParseIP(ip), Score: currentScore}, true
 			}
 		}
-	}()
-	sip := <-result
-	return &sip, nil
+		return nil, false
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, &base.TimeoutError{}
+		case r, ok := <-c:
+			if !ok {
+				return nil, &base.NotRetrievedError{}
+			}
+			if r.err != nil {
+				sumOfWeight -= r.source.Weight
+			} else {
+				key := r.scoredIP.IP.String()
+				m[key] += r.scoredIP.Score
+				sumOfWeight -= (r.scoredIP.MaxScore - r.scoredIP.Score)
+			}
+			if sip, ok := winner(); ok {
+				cancel()
+				return sip, nil
+			}
+		}
+	}
 }
 
 var timeout = flag.Duration("timeout", 3*time.Second, "Timeout duration.")

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/kitsuyui/myip/resolvers/base"
+)
+
+type fakeRetriever struct {
+	ip    string
+	score float64
+	delay time.Duration
+	err   error
+}
+
+func (f fakeRetriever) RetrieveIP() (*base.ScoredIP, error) {
+	time.Sleep(f.delay)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &base.ScoredIP{IP: net.ParseIP(f.ip), Score: f.score}, nil
+}
+
+func (f fakeRetriever) String() string {
+	return f.ip
+}
+
+func TestPickUpReturnsErrorWhenNoResultExceedsThreshold(t *testing.T) {
+	retrievers := []base.ScoredIPRetrievable{
+		{IPRetrievable: fakeRetriever{ip: "192.0.2.1", score: 1.0}, Weight: 1.0},
+		{IPRetrievable: fakeRetriever{ip: "192.0.2.2", score: 1.0}, Weight: 1.0},
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := pickUpFirstItemThatExceededThreshold(retrievers, time.Second, 1.1)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("pickUpFirstItemThatExceededThreshold did not return")
+	}
+}
+
+func TestPickUpDoesNotPanicOnLateResultAfterWinner(t *testing.T) {
+	retrievers := []base.ScoredIPRetrievable{
+		{IPRetrievable: fakeRetriever{ip: "192.0.2.1", score: 1.0}, Weight: 1.0},
+		{IPRetrievable: fakeRetriever{ip: "192.0.2.2", score: 1.0, delay: 20 * time.Millisecond}, Weight: 1.0},
+	}
+	sip, err := pickUpFirstItemThatExceededThreshold(retrievers, time.Second, 0.4)
+	if err != nil {
+		t.Fatalf("expected winner: %v", err)
+	}
+	if sip.IP.String() != "192.0.2.1" {
+		t.Fatalf("unexpected IP: %s", sip.IP.String())
+	}
+
+	time.Sleep(50 * time.Millisecond)
+}

--- a/resolvers/base/base.go
+++ b/resolvers/base/base.go
@@ -59,7 +59,7 @@ func (p ScoredIPRetrievable) RetrieveIPWithScoring(ctx context.Context) (*Scored
 		ScoredIP *ScoredIP
 		Err      error
 	}
-	c := make(chan Result)
+	c := make(chan Result, 1)
 	go func() {
 		scoredIP, err := p.RetrieveIP()
 		c <- Result{scoredIP, err}


### PR DESCRIPTION
## Summary

Fix result aggregation so the CLI returns cleanly when no detector exceeds the threshold and does not panic when slower detectors report after a winner has already been selected.

## Details

- Track detector completion with a `WaitGroup` and close the aggregation channel only after senders finish.
- Cancel the shared context once a winning IP is selected.
- Buffer the per-detector scoring channel so a timed-out caller does not leave the retrieval goroutine blocked on send.
- Add regression tests for the no-winner case and a late detector result after an early winner.

## Verification

- `go test ./...`
- `git diff --check main...HEAD`
