### PR TITLE
docs: fix documented default threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Options:
  -6 --ipv6               						 Prefer IPv6.
  -n --newline            						 Show IP with newline.
  -N --no-newline         						 Show IP without newline.
- -T=<rate> --threshold=<rate>  			 Threshold that must be exceeded by weighted votes [default: 0.5].
+ -T=<rate> --threshold=<rate>  			 Threshold that must be exceeded by weighted votes [default: 0.6].
  -t=<duration> --timeout=<duration>  Timeout [default: 3s].
 ```
 


### PR DESCRIPTION
## Summary

- Update the README help example so the documented `--threshold` default matches the command help and implementation.

## Why

The README listed the default threshold as `0.5`, while the CLI help in `cmd/main.go` advertises `0.6`. This could lead users to expect a less strict weighted-vote threshold than the tool actually uses.

## Validation

- `go run ./cmd --help`
- `go test ./...`
- `git diff --check`