### PR TITLE
Set explicit workflow permissions

### DIFF
--- a/.github/workflows/golang-test.yml
+++ b/.github/workflows/golang-test.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test
@@ -41,4 +45,3 @@ jobs:
           distribution: goreleaser
           version: "~> v2"
           args: build --snapshot --clean
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+permissions:
+  contents: read
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -40,6 +43,8 @@ jobs:
   deploy:
     needs: goreleaser
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v7


### PR DESCRIPTION
## Summary

- Add read-only top-level workflow permissions to the Go test workflow.
- Add read-only default permissions to the release workflow.
- Grant `contents: write` only to the release deployment job that publishes GitHub release assets.

## Validation

- `ruby -ryaml -e "YAML.load_file('.github/workflows/golang-test.yml'); YAML.load_file('.github/workflows/release.yml')"`
- `actionlint .github/workflows/golang-test.yml .github/workflows/release.yml`
- `git diff --check`
