### PR TITLE
Pin workflow action refs to 40-character commit SHAs

### DIFF
--- a/.github/workflows/golang-test.yml
+++ b/.github/workflows/golang-test.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: setup
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ^1.19.4
           check-latest: true
@@ -40,7 +40,7 @@ jobs:
         run: go build ./...
 
       - name: cross build
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,25 +16,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: setup
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ^1.19.4
           check-latest: true
 
       - name: release
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: "~> v2"
           args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Upload assets
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: release-assets-${{ github.sha }}
           path: dist/*
@@ -47,7 +47,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: release-assets-${{ github.sha }}
           merge-multiple: true
@@ -58,6 +58,6 @@ jobs:
 
       - name: Release
         if: github.event_name == 'release' && !github.event.release.prerelease
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: ./dist/**/*

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@9108d679c02a52824376afcf071715fdaaa2a4e4 # main


### PR DESCRIPTION
## Summary

Pin the ten external `uses:` references in `.github/workflows/` to 40-character commit SHAs (resolved tag tips, verified via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`):

| File | Before | After |
| --- | --- | --- |
| `golang-test.yml:22` | `actions/checkout@v6` | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6` |
| `golang-test.yml:25` | `actions/setup-go@v6` | `@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6` |
| `golang-test.yml:43` | `goreleaser/goreleaser-action@v6` | `@e435ccd777264be153ace6237001ef4d979d3a7a # v6` |
| `release.yml:19` | `actions/checkout@v6` | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6` |
| `release.yml:22` | `actions/setup-go@v6` | `@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6` |
| `release.yml:28` | `goreleaser/goreleaser-action@v6` | `@e435ccd777264be153ace6237001ef4d979d3a7a # v6` |
| `release.yml:37` | `actions/upload-artifact@v6` | `@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6` |
| `release.yml:50` | `actions/download-artifact@v7` | `@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7` |
| `release.yml:61` | `softprops/action-gh-release@v2` | `@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2` |
| `spellcheck.yml:8` | `kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main` | `@9108d679c02a52824376afcf071715fdaaa2a4e4 # main` |

Tag references (`@v6`, `@v7`, `@v2`, `@main`) let upstream silently move
content under our CI/CD pipeline. Pinning to a 40-character SHA fixes
the supply-chain input.

The audit finding mentioned the count as "ten references" but only 6 evidence
lines were listed; this PR pins all 10 to align the workflow with the
finding text.

Renovate already extends `helpers:pinGitHubActionDigests` via
`local>kitsuyui/renovate-config`, so future digest updates continue
through automated PRs.

## Test plan

- [x] Each SHA verified as the v6/v7/v2/main tip via `gh api repos/.../git/refs/tags/...`
- [x] `git diff` confirms only the ten `uses:` lines (and one trailing-whitespace cleanup on the line between two pinned uses) change
