### PR TITLE
Add build provenance attestation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
@@ -59,6 +61,12 @@ jobs:
 
       - name: List
         run: find ./dist
+
+      - name: Generate build provenance attestation
+        if: github.event_name == 'release' && !github.event.release.prerelease
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: './dist/*'
 
       - name: Release
         if: github.event_name == 'release' && !github.event.release.prerelease


### PR DESCRIPTION
## Summary

This PR adds build provenance attestation to the release workflow using `actions/attest-build-provenance`. On each non-prerelease release, all release artifacts in `dist/` are attested with a Sigstore-backed SLSA build provenance record. This allows downstream tools (e.g. `gh attestation verify`) to verify that release binaries were built by this repository's official CI pipeline.

## Validation

The attestation step is guarded by the same `if: github.event_name == 'release' && !github.event.release.prerelease` condition as the release upload step, so it only fires on real releases. The `id-token: write` and `attestations: write` permissions are added to the deploy job (not the goreleaser job). The action SHA is pinned to the commit hash for the v4.1.0 tag.

## Notes

Verification: `gh attestation verify <binary> --repo kitsuyui/myip`
