### PR TITLE
fix: propagate HTTP request cancellation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"log"
 	"net"
@@ -46,7 +46,7 @@ func pickUpFirstItemThatExceededThreshold(siprs []base.ScoredIPRetrievable, time
 	if verboseMode {
 		logger.SetOutput(os.Stderr)
 	} else {
-		logger.SetOutput(ioutil.Discard)
+		logger.SetOutput(io.Discard)
 	}
 	type result struct {
 		scoredIP base.ScoredIPWithMaxScore
@@ -174,7 +174,7 @@ Options:
 		duration = time.Duration(f) * time.Second
 	}
 	sip, err := pickUpFirstItemThatExceededThreshold(sir, duration, threshold)
-	if err == nil && sip.Score >= threshold {
+	if err == nil {
 		fmt.Print(sip.IP.String())
 		if newline, _ := opts.Bool("--newline"); newline {
 			fmt.Println("")

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -48,6 +48,20 @@ func TestPickUpReturnsErrorWhenNoResultExceedsThreshold(t *testing.T) {
 	}
 }
 
+func TestPickUpRequiresScoreToExceedThreshold(t *testing.T) {
+	retrievers := []base.ScoredIPRetrievable{
+		{IPRetrievable: fakeRetriever{ip: "192.0.2.1", score: 1.0}, Weight: 1.0},
+	}
+
+	_, err := pickUpFirstItemThatExceededThreshold(retrievers, time.Second, 1.0)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if _, ok := err.(*base.NotRetrievedError); !ok {
+		t.Fatalf("expected NotRetrievedError, got %T", err)
+	}
+}
+
 func TestPickUpDoesNotPanicOnLateResultAfterWinner(t *testing.T) {
 	retrievers := []base.ScoredIPRetrievable{
 		{IPRetrievable: fakeRetriever{ip: "192.0.2.1", score: 1.0}, Weight: 1.0},

--- a/resolvers/base/base.go
+++ b/resolvers/base/base.go
@@ -43,15 +43,15 @@ type IPRetrievable interface {
 	String() string
 }
 
+type contextIPRetrievable interface {
+	RetrieveIPWithContext(context.Context) (*ScoredIP, error)
+}
+
 type ScoredIPRetrievable struct {
 	IPRetrievable
 	Weight float64
 	IPv4   bool
 	IPv6   bool
-}
-
-func (s ScoredIP) addWeight(weight float64) ScoredIP {
-	return ScoredIP{s.IP, s.Score * weight}
 }
 
 func (p ScoredIPRetrievable) RetrieveIPWithScoring(ctx context.Context) (*ScoredIPWithMaxScore, error) {
@@ -61,7 +61,7 @@ func (p ScoredIPRetrievable) RetrieveIPWithScoring(ctx context.Context) (*Scored
 	}
 	c := make(chan Result, 1)
 	go func() {
-		scoredIP, err := p.RetrieveIP()
+		scoredIP, err := p.retrieveIP(ctx)
 		c <- Result{scoredIP, err}
 	}()
 	select {
@@ -77,4 +77,11 @@ func (p ScoredIPRetrievable) RetrieveIPWithScoring(ctx context.Context) (*Scored
 		}
 		return nil, r.Err
 	}
+}
+
+func (p ScoredIPRetrievable) retrieveIP(ctx context.Context) (*ScoredIP, error) {
+	if retriever, ok := p.IPRetrievable.(contextIPRetrievable); ok {
+		return retriever.RetrieveIPWithContext(ctx)
+	}
+	return p.RetrieveIP()
 }

--- a/resolvers/base/base_test.go
+++ b/resolvers/base/base_test.go
@@ -1,0 +1,46 @@
+package base
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type contextAwareRetriever struct {
+	canceled chan struct{}
+}
+
+func (r contextAwareRetriever) RetrieveIP() (*ScoredIP, error) {
+	return nil, errors.New("RetrieveIP fallback should not be called")
+}
+
+func (r contextAwareRetriever) RetrieveIPWithContext(ctx context.Context) (*ScoredIP, error) {
+	<-ctx.Done()
+	close(r.canceled)
+	return nil, ctx.Err()
+}
+
+func (r contextAwareRetriever) String() string {
+	return "context-aware"
+}
+
+func TestRetrieveIPWithScoringPropagatesContext(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	retriever := contextAwareRetriever{canceled: make(chan struct{})}
+	_, err := ScoredIPRetrievable{IPRetrievable: retriever, Weight: 1.0}.RetrieveIPWithScoring(ctx)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if _, ok := err.(*TimeoutError); !ok {
+		t.Fatalf("expected TimeoutError, got %T", err)
+	}
+
+	select {
+	case <-retriever.canceled:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("context was not propagated to retriever")
+	}
+}

--- a/resolvers/http_resolver/http_resolver.go
+++ b/resolvers/http_resolver/http_resolver.go
@@ -3,8 +3,9 @@
 package http_resolver
 
 import (
+	"context"
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -35,13 +36,22 @@ func scoreOfTLS(t *tls.ConnectionState) float64 {
 }
 
 func (p HTTPDetector) RetrieveIP() (*base.ScoredIP, error) {
+	return p.RetrieveIPWithContext(context.Background())
+}
+
+// RetrieveIPWithContext retrieves an IP address using an HTTP request bound to ctx.
+func (p HTTPDetector) RetrieveIPWithContext(ctx context.Context) (*base.ScoredIP, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.URL, nil)
+	if err != nil {
+		return nil, err
+	}
 	client := http.Client{}
-	resp, err := client.Get(p.URL)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/resolvers/http_resolver/http_resolver_test.go
+++ b/resolvers/http_resolver/http_resolver_test.go
@@ -1,23 +1,36 @@
 package http_resolver
 
 import (
+	"context"
 	"crypto/tls"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestHTTPSuccess(t *testing.T) {
-	h := HTTPDetector{URL: "http://whatismyip.akamai.com/"}
-	ip, err := h.RetrieveIP()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("203.0.113.10\n"))
+	}))
+	defer server.Close()
+
+	h := HTTPDetector{URL: server.URL}
+	scoredIP, err := h.RetrieveIP()
 	if err != nil {
-		t.Errorf("Should be succeed")
+		t.Errorf("Should be succeed: %v", err)
 	}
-	if ip == nil {
-		t.Errorf("IP must not nil")
+	if scoredIP == nil {
+		t.Fatal("IP must not nil")
+	}
+	if scoredIP.IP.String() != "203.0.113.10" {
+		t.Errorf("unexpected IP: %s", scoredIP.IP.String())
 	}
 }
 
 func TestHTTPFail(t *testing.T) {
-	h := HTTPDetector{URL: "http://127.0.0.1/"}
+	h := HTTPDetector{URL: "://bad-url"}
 	ip, err := h.RetrieveIP()
 	if err == nil {
 		t.Errorf("This should be error")
@@ -28,13 +41,40 @@ func TestHTTPFail(t *testing.T) {
 }
 
 func TestHTTPFail2(t *testing.T) {
-	h := HTTPDetector{URL: "http://example.com/"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("not an ip"))
+	}))
+	defer server.Close()
+
+	h := HTTPDetector{URL: server.URL}
 	ip, err := h.RetrieveIP()
 	if err == nil {
 		t.Errorf("This should be error")
 	}
 	if ip != nil {
 		t.Errorf("IP should be nil when error")
+	}
+}
+
+func TestHTTPContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	h := HTTPDetector{URL: server.URL}
+	ip, err := h.RetrieveIPWithContext(ctx)
+	if err == nil {
+		t.Fatal("expected context error")
+	}
+	if ip != nil {
+		t.Fatalf("IP should be nil when context is canceled: %v", ip)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Propagate scoring timeout cancellation into HTTP resolver requests.
- Keep the existing `RetrieveIP` compatibility path for callers that do not pass a context.
- Remove the redundant final threshold check and cover the strict threshold boundary.

## Testing
- `go vet ./...`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `go build ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./cmd/... ./resolvers/base ./resolvers/http_resolver`
