### PR TITLE
Fix DNS resolver QueryType validation and nil IP from TXT record

### DIFF
--- a/resolvers/dns_resolver/dns_resolver.go
+++ b/resolvers/dns_resolver/dns_resolver.go
@@ -12,6 +12,12 @@ import (
 	"github.com/kitsuyui/myip/resolvers/base"
 )
 
+// Supported QueryType values for DNSDetector.
+const (
+	QueryTypeA   = "A"
+	QueryTypeTXT = "TXT"
+)
+
 type DNSDetector struct {
 	LookupDomainName string `json:"name"`
 	Resolver         string `json:"server"`
@@ -19,10 +25,14 @@ type DNSDetector struct {
 }
 
 func (p DNSDetector) RetrieveIP() (*base.ScoredIP, error) {
-	if strings.ToUpper(p.QueryType) == "TXT" {
+	switch strings.ToUpper(p.QueryType) {
+	case QueryTypeTXT:
 		return p.RetrieveIPByTXTRecord()
+	case QueryTypeA, "":
+		return p.RetrieveIPByARecord()
+	default:
+		return nil, &base.NotRetrievedError{Message: fmt.Sprintf("unsupported QueryType: %q (supported: %q, %q)", p.QueryType, QueryTypeA, QueryTypeTXT)}
 	}
-	return p.RetrieveIPByARecord()
 }
 
 func (p DNSDetector) RetrieveIPByARecord() (*base.ScoredIP, error) {
@@ -59,13 +69,16 @@ func (p DNSDetector) RetrieveIPByTXTRecord() (*base.ScoredIP, error) {
 		return nil, &base.NotRetrievedError{}
 	}
 	ip := net.ParseIP(txtRecord.Txt[0])
+	if ip == nil {
+		return nil, &base.NotRetrievedError{Message: fmt.Sprintf("TXT record %q is not a valid IP address", txtRecord.Txt[0])}
+	}
 	return &base.ScoredIP{IP: ip, Score: 1.0}, nil
 }
 
 func (p DNSDetector) String() string {
-	qt := "A"
-	if strings.ToUpper(p.QueryType) == "TXT" {
-		qt = "TXT"
+	qt := QueryTypeA
+	if strings.ToUpper(p.QueryType) == QueryTypeTXT {
+		qt = QueryTypeTXT
 	}
 	return fmt.Sprintf("%s,%s,%s", qt, p.LookupDomainName, p.Resolver)
 }

--- a/resolvers/dns_resolver/dns_resolver_test.go
+++ b/resolvers/dns_resolver/dns_resolver_test.go
@@ -69,6 +69,17 @@ func TestDNSTXTRecordFailWhenInvalidLookup(t *testing.T) {
 		t.Errorf("IP should be nil when error")
 	}
 }
+func TestUnsupportedQueryType(t *testing.T) {
+	d := DNSDetector{LookupDomainName: "example.com.", Resolver: "8.8.8.8:53", QueryType: "MX"}
+	ip, err := d.RetrieveIP()
+	if err == nil {
+		t.Errorf("Unsupported QueryType should return an error")
+	}
+	if ip != nil {
+		t.Errorf("IP should be nil when error")
+	}
+}
+
 func TestGetString(t *testing.T) {
 	result := DNSDetector{LookupDomainName: "dummy.myaddr.l.google.com.", Resolver: "ns1.google.com:53", QueryType: "TXT"}.String()
 	tobe := "TXT,dummy.myaddr.l.google.com.,ns1.google.com:53"


### PR DESCRIPTION
## Summary

- `RetrieveIP()` previously fell back silently to an A record query for any unrecognized `QueryType` value (e.g. `"MX"`, `"AAAA"`). It now returns a descriptive error for unsupported types. Only `"A"` (or empty string, for backwards compatibility) and `"TXT"` are accepted.
- `RetrieveIPByTXTRecord()` previously returned `ScoredIP{IP: nil}` with a `nil` error when the TXT record content was not a valid IP address. It now returns a `NotRetrievedError` instead, preventing nil pointer dereferences in callers.
- Exports `QueryTypeA` and `QueryTypeTXT` string constants so callers can reference supported values without bare literals.

## Validation

- `go fmt ./...` — no diff
- `go vet ./...` — clean
- `go test ./...` — all pass, including new `TestUnsupportedQueryType`

## Notes

Empty `QueryType` continues to behave as `"A"` to avoid breaking existing configs that omit the field.