### PR TITLE
fix(resolvers): add explicit timeout to DNS and STUN operations

### DIFF
--- a/resolvers/dns_resolver/dns_resolver.go
+++ b/resolvers/dns_resolver/dns_resolver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/miekg/dns"
 
@@ -17,6 +18,10 @@ const (
 	QueryTypeA   = "A"
 	QueryTypeTXT = "TXT"
 )
+
+// dnsTimeout limits each DNS exchange so goroutines in base.RetrieveIPWithScoring
+// cannot outlive the caller's context deadline by more than this duration.
+const dnsTimeout = 5 * time.Second
 
 type DNSDetector struct {
 	LookupDomainName string `json:"name"`
@@ -36,7 +41,7 @@ func (p DNSDetector) RetrieveIP() (*base.ScoredIP, error) {
 }
 
 func (p DNSDetector) RetrieveIPByARecord() (*base.ScoredIP, error) {
-	c := dns.Client{}
+	c := dns.Client{Timeout: dnsTimeout}
 	m := dns.Msg{}
 	m.SetQuestion(p.LookupDomainName, dns.TypeA)
 	result, _, err := c.Exchange(&m, p.Resolver)
@@ -54,7 +59,7 @@ func (p DNSDetector) RetrieveIPByARecord() (*base.ScoredIP, error) {
 }
 
 func (p DNSDetector) RetrieveIPByTXTRecord() (*base.ScoredIP, error) {
-	c := dns.Client{}
+	c := dns.Client{Timeout: dnsTimeout}
 	m := dns.Msg{}
 	m.SetQuestion(p.LookupDomainName, dns.TypeTXT)
 	result, _, err := c.Exchange(&m, p.Resolver)

--- a/resolvers/stun_resolver/stun_resolver.go
+++ b/resolvers/stun_resolver/stun_resolver.go
@@ -8,10 +8,15 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"time"
 
 	"github.com/kitsuyui/myip/resolvers/base"
 	"gortc.io/stun"
 )
+
+// dialTimeout limits each STUN dial so goroutines in base.RetrieveIPWithScoring
+// cannot outlive the caller's context deadline by more than this duration.
+const dialTimeout = 5 * time.Second
 
 type STUNDetector struct {
 	Host     string `json:"host"`
@@ -29,16 +34,17 @@ func (p STUNDetector) RetrieveIP() (*base.ScoredIP, error) {
 	}
 	scheme := uri.Scheme
 	address := uri.Host + ":" + strconv.Itoa(uri.Port)
+	dialer := &net.Dialer{Timeout: dialTimeout}
 	if scheme == stun.SchemeSecure {
 		cfg := &tls.Config{
 			ServerName: uri.Host,
 		}
-		conn, err = tls.Dial(p.Protocol, address, cfg)
+		conn, err = tls.DialWithDialer(dialer, p.Protocol, address, cfg)
 		if err != nil {
 			return nil, &base.NotRetrievedError{}
 		}
 	} else {
-		conn, err = net.Dial(p.Protocol, address)
+		conn, err = dialer.Dial(p.Protocol, address)
 		if err != nil {
 			return nil, &base.NotRetrievedError{}
 		}


### PR DESCRIPTION
## Summary

- Add explicit 5-second timeout to `dns.Client` in both `RetrieveIPByARecord` and `RetrieveIPByTXTRecord` (`resolvers/dns_resolver/dns_resolver.go`)
- Add explicit 5-second dial timeout to STUN resolver via `net.Dialer{Timeout: dialTimeout}`, applied to both plain (`dialer.Dial`) and TLS (`tls.DialWithDialer`) paths (`resolvers/stun_resolver/stun_resolver.go`)

`base.RetrieveIPWithScoring` spawns goroutines that call `p.RetrieveIP()` and selects on `ctx.Done()`. Without I/O-level timeouts, a DNS `Exchange` or STUN `Dial` call blocks indefinitely — the goroutine outlives the 3-second user-visible context timeout and runs until the OS UDP retransmission timeout. With `dnsTimeout`/`dialTimeout = 5s`, goroutines exit within 5 seconds of context cancellation.

## Validation

- `go build ./...` passes
- `go vet ./...` passes
- Existing unit tests (`go test ./...`) pass without modification

## Notes

This is a bounded fix that caps goroutine lifetime without changing the `IPRetrievable` interface. Full context propagation (passing `ctx` through the interface) would eliminate goroutine overlap entirely but requires a wider breaking change across all resolvers.
