### PR TITLE
fix(resolvers): replace deprecated io/ioutil with io package

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"log"
 	"net"
@@ -46,7 +46,7 @@ func pickUpFirstItemThatExceededThreshold(siprs []base.ScoredIPRetrievable, time
 	if verboseMode {
 		logger.SetOutput(os.Stderr)
 	} else {
-		logger.SetOutput(ioutil.Discard)
+		logger.SetOutput(io.Discard)
 	}
 	type result struct {
 		scoredIP base.ScoredIPWithMaxScore

--- a/resolvers/http_resolver/http_resolver.go
+++ b/resolvers/http_resolver/http_resolver.go
@@ -4,7 +4,7 @@ package http_resolver
 
 import (
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -41,7 +41,7 @@ func (p HTTPDetector) RetrieveIP() (*base.ScoredIP, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Replace `ioutil.Discard` with `io.Discard` in `cmd/main.go`
- Replace `ioutil.ReadAll` with `io.ReadAll` in `resolvers/http_resolver/http_resolver.go`
- Remove `io/ioutil` import in both files, replaced with `io`

The `io/ioutil` package was deprecated in Go 1.16. The repository already requires Go 1.21+ (`go.mod`), so `io.Discard` and `io.ReadAll` are available without any compatibility concerns.

## Validation

- `go fmt ./...`: no changes
- `go vet ./...`: clean
- `go test ./...`: all tests pass
- `staticcheck ./...`: no `SA1019` (deprecated API) findings remain; two pre-existing unrelated findings (U1000, S1025) are out of scope for this change