### PR TITLE
fix(cmd): fall back to reflect type name in typeName() for unknown resolvers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,7 @@ func typeName(ipr interface{}) string {
 	case stun_resolver.STUNDetector:
 		return "stun"
 	}
-	return ""
+	return fmt.Sprintf("%T", ipr)
 }
 
 func pickUpFirstItemThatExceededThreshold(siprs []base.ScoredIPRetrievable, timeout time.Duration, threshold float64) (*base.ScoredIP, error) {


### PR DESCRIPTION
## Summary

Replace the silent empty-string fallback in `typeName()` with a reflection-based fallback that returns the qualified Go type name.

**Before:**
```go
func typeName(ipr interface{}) string {
    switch ipr.(type) {
    case http_resolver.HTTPDetector:
        return "http"
    // ...
    }
    return ""  // silent empty for unknown types
}
```

**After:**
```go
    return fmt.Sprintf("%T", ipr)  // e.g. "newpkg.NewDetector"
```

## Problem

`typeName()` is used in verbose log output:
```
IP:<addr>  type:<name>  weight:<w>  <url>
```

When a new resolver type is added to `resolvers/targets/targets.go` but `typeName()` is not updated, the `type:` field becomes blank. This is a silent failure — no compile error, no CI failure, just missing information in verbose logs.

## Fix

`fmt.Sprintf("%T", ipr)` returns the package-qualified type name (e.g., `newpkg.NewDetector`) for any type not in the switch. This makes registration omissions immediately visible in verbose output and removes the empty-string failure mode.

## Validation

- `go fmt ./...`: no changes
- `go vet ./...`: clean
- `go test ./...`: all tests pass
- `staticcheck ./...`: no new findings introduced (pre-existing `SA1019`/`U1000`/`S1025` are unrelated and addressed separately)