### PR TITLE
fix(cmd): default to trailing newline; wire --no-newline flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -175,9 +175,10 @@ Options:
 	}
 	sip, err := pickUpFirstItemThatExceededThreshold(sir, duration, threshold)
 	if err == nil {
-		fmt.Print(sip.IP.String())
-		if newline, _ := opts.Bool("--newline"); newline {
-			fmt.Println("")
+		if noNewline, _ := opts.Bool("--no-newline"); noNewline {
+			fmt.Print(sip.IP.String())
+		} else {
+			fmt.Println(sip.IP.String())
 		}
 	} else {
 		if err != nil {


### PR DESCRIPTION
## Summary

- `cmd/main.go` now calls `fmt.Println` by default so output is newline-terminated.
- The `--no-newline` flag suppresses the trailing newline when explicitly requested.
- Previously the `--no-newline` flag was listed in `--help` but never read from the parsed options (dead code). This commit wires it up.

## Problem

POSIX defines a text file as a sequence of lines each terminated by `\n`. The previous default (`fmt.Print` without a newline) violated this:

- `myip > /tmp/ip.txt` produced a non-POSIX text file.
- `myip | wc -l` returned `0` instead of `1`.
- Running `myip; echo done` printed the prompt on the same line as the IP address.
- `--help` advertised `--no-newline` but the flag was silently ignored, making the documentation misleading.

## What changed

`cmd/main.go` — one block changed:

| Before | After |
|--------|-------|
| `fmt.Print(sip.IP.String())` default; `--newline` flag adds `\n` | `fmt.Println(sip.IP.String())` default; `--no-newline` suppresses `\n` |

The `--newline` option (opt-in newline) is replaced by `--no-newline` (opt-out newline), which was already the documented interface.

## Backward compatibility

Scripts that consumed the output without a trailing newline will now receive one. This is a **breaking change only for callers that relied on the absence of a newline** — the standard POSIX expectation is that text output ends with `\n`, so the new behavior is the correct default.

## Validation

```sh
# Newline present by default
myip | xxd | tail -1   # last byte should be 0a

# Newline suppressed with flag
myip --no-newline | xxd | tail -1   # last byte should NOT be 0a

# Pipeline sanity check
myip | wc -l   # should return 1
```
