### PR TITLE
fix(dns_resolver): guard against nil IP from ParseIP in TXT resolver

### DIFF
--- a/resolvers/dns_resolver/dns_resolver.go
+++ b/resolvers/dns_resolver/dns_resolver.go
@@ -59,6 +59,9 @@ func (p DNSDetector) RetrieveIPByTXTRecord() (*base.ScoredIP, error) {
 		return nil, &base.NotRetrievedError{}
 	}
 	ip := net.ParseIP(txtRecord.Txt[0])
+	if ip == nil {
+		return nil, &base.NotRetrievedError{}
+	}
 	return &base.ScoredIP{IP: ip, Score: 1.0}, nil
 }
 


### PR DESCRIPTION
## Summary

- `RetrieveIPByTXTRecord` did not check whether `net.ParseIP` returned nil before
  constructing a `ScoredIP`, unlike `RetrieveIPByARecord` (line 40) and the HTTP
  resolver (line 50) which both return `NotRetrievedError` on a nil result.
- If a TXT record contains a string that is not a valid IP address, `net.ParseIP`
  returns nil, and the caller receives a `ScoredIP{IP: nil}` with no error — silently
  breaking the "returns IP or returns error" contract of the function.

## Validation

- `go vet ./...` passes
- `go test ./...` passes (all packages)
- `staticcheck ./...` — no new findings introduced by this change

## Notes

- The nil guard added here mirrors the existing pattern in `RetrieveIPByARecord` and
  `http_resolver.RetrieveIP`.
- In practice, the `o-o.myaddr.l.google.com.` TXT query always returns a valid IP, so
  this path is not exercised in normal operation. The fix closes a contract gap that
  would surface with a malformed or adversarial DNS response.
