### PR TITLE
fix(dns_resolver): guard against empty Txt slice in TXT resolver

### DIFF
--- a/resolvers/dns_resolver/dns_resolver.go
+++ b/resolvers/dns_resolver/dns_resolver.go
@@ -55,7 +55,7 @@ func (p DNSDetector) RetrieveIPByTXTRecord() (*base.ScoredIP, error) {
 		return nil, &base.NotRetrievedError{}
 	}
 	txtRecord := result.Answer[0].(*dns.TXT)
-	if txtRecord.Txt == nil {
+	if len(txtRecord.Txt) == 0 {
 		return nil, &base.NotRetrievedError{}
 	}
 	ip := net.ParseIP(txtRecord.Txt[0])


### PR DESCRIPTION
## Summary

- `RetrieveIPByTXTRecord` checked `txtRecord.Txt == nil` but did not guard against a
  non-nil, zero-length slice. When `Txt` is `[]string{}`, the next line `Txt[0]` panics
  with "index out of range".
- DNS allows a TXT record with zero string segments (TXT RDATA = 0 bytes); `miekg/dns`
  represents this as `Txt: []string{}`. This is a valid, spec-conforming DNS response,
  not a malformed one.
- Replace the nil check with `len(txtRecord.Txt) == 0`, which covers both nil and empty.

## Validation

- `go vet ./...` passes
- `go test ./...` passes (all packages)
- `staticcheck ./...` — no new findings introduced by this change

## Notes

- The panic would propagate through the goroutine launched in `cmd/main.go` without
  a `recover`, crashing the process. This path is not exercised by the default
  `o-o.myaddr.l.google.com.` query under normal conditions, but is reachable with a
  mock DNS server or in a DNS-manipulation environment.
