### PR TITLE
fix(http_resolver): treat TLS versions >= 1.3 as highest trust score

### DIFF
--- a/resolvers/http_resolver/http_resolver.go
+++ b/resolvers/http_resolver/http_resolver.go
@@ -20,9 +20,10 @@ func scoreOfTLS(t *tls.ConnectionState) float64 {
 	if t == nil { // HTTP
 		return 0.1
 	}
-	switch t.Version {
-	case tls.VersionTLS13:
+	if t.Version >= tls.VersionTLS13 {
 		return 1.0
+	}
+	switch t.Version {
 	case tls.VersionTLS12:
 		return 0.8
 	case tls.VersionTLS11:


### PR DESCRIPTION
## Summary

- `scoreOfTLS` mapped known TLS versions (1.0–1.3) to trust scores, with a `default`
  fallback of `0.2` — lower than even TLS 1.0 (`0.4`). Any future TLS version added to
  `crypto/tls` would therefore receive a lower trust score than the oldest known version,
  penalizing connections made with a more secure protocol.
- Replace the explicit `case tls.VersionTLS13` with a `>= tls.VersionTLS13` guard
  clause so that versions numerically higher than TLS 1.3 also receive the maximum
  score (`1.0`). TLS version numbers are monotonically increasing in Go's `crypto/tls`,
  so this is a stable comparison.

## Validation

- `go vet ./...` passes
- `go test ./...` passes (all packages, including `http_resolver`)
- `staticcheck ./...` — no new findings introduced by this change

## Notes

- The `default: 0.2` branch is retained for truly unrecognized version values (e.g.
  SSL 3.0 or values that are not a standard TLS version). Only values `>= VersionTLS13`
  receive the upgrade to `1.0`.
- TLS version numbering in Go: TLS 1.0 = 0x0301, TLS 1.1 = 0x0302, TLS 1.2 = 0x0303,
  TLS 1.3 = 0x0304. Any future version would be ≥ 0x0304.
