### PR TITLE
fix(cmd): print failure reason to stderr before exiting

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -180,6 +180,11 @@ Options:
 			fmt.Println("")
 		}
 	} else {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		} else {
+			fmt.Fprintln(os.Stderr, "error: consensus threshold not reached")
+		}
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

- Print a descriptive error message to stderr before exiting with code 1
- Distinguishes between timeout (`Timeout`), all-resolver failure (`No Answer`), and consensus threshold not reached
- Previously, any failure caused a silent `os.Exit(1)` with no output, making diagnosis from scripts impossible without re-running with `-v`

## Validation

- `go build ./...` passes
- `go test ./...` passes (all packages)
- `go vet ./...` passes
- `gofmt` reports no changes

## Notes

The fix targets the `else` branch of the final threshold check in `cmd/main.go`. The error message uses the existing `Error()` method of `base.TimeoutError` and `base.NotRetrievedError` types, so the message text is consistent with what verbose mode already logs per-resolver.
