### PR TITLE
fix(resolvers): guard against unexpected DNS record types and fix STUN client leak

### DIFF
--- a/resolvers/dns_resolver/dns_resolver.go
+++ b/resolvers/dns_resolver/dns_resolver.go
@@ -46,8 +46,8 @@ func (p DNSDetector) RetrieveIPByARecord() (*base.ScoredIP, error) {
 	if len(result.Answer) == 0 {
 		return nil, &base.NotRetrievedError{}
 	}
-	arecord := result.Answer[0].(*dns.A)
-	if arecord.A == nil {
+	arecord, ok := result.Answer[0].(*dns.A)
+	if !ok || arecord.A == nil {
 		return nil, &base.NotRetrievedError{}
 	}
 	return &base.ScoredIP{IP: arecord.A, Score: 1.0}, nil
@@ -64,8 +64,8 @@ func (p DNSDetector) RetrieveIPByTXTRecord() (*base.ScoredIP, error) {
 	if len(result.Answer) == 0 {
 		return nil, &base.NotRetrievedError{}
 	}
-	txtRecord := result.Answer[0].(*dns.TXT)
-	if len(txtRecord.Txt) == 0 {
+	txtRecord, ok := result.Answer[0].(*dns.TXT)
+	if !ok || len(txtRecord.Txt) == 0 {
 		return nil, &base.NotRetrievedError{}
 	}
 	ip := net.ParseIP(txtRecord.Txt[0])

--- a/resolvers/stun_resolver/stun_resolver.go
+++ b/resolvers/stun_resolver/stun_resolver.go
@@ -47,6 +47,7 @@ func (p STUNDetector) RetrieveIP() (*base.ScoredIP, error) {
 	if err != nil {
 		return nil, &base.NotRetrievedError{}
 	}
+	defer c.Close()
 	var err2 error
 	if err := c.Do(stun.MustBuild(stun.TransactionID, stun.BindingRequest), func(res stun.Event) {
 		if res.Error != nil {
@@ -62,7 +63,6 @@ func (p STUNDetector) RetrieveIP() (*base.ScoredIP, error) {
 	}); err != nil || err2 != nil {
 		return nil, &base.NotRetrievedError{}
 	}
-	defer c.Close()
 	if scheme == stun.SchemeSecure {
 		return &base.ScoredIP{IP: ip, Score: 1.0}, nil
 	} else {


### PR DESCRIPTION
## Summary

- Use comma-ok type assertions in `dns_resolver` so that unexpected answer record types (e.g. CNAME in a TypeA response) return `NotRetrievedError` instead of panicking and crashing the myip process.
- Move `defer c.Close()` immediately after `stun.NewClient` succeeds so the STUN client is always closed even when `c.Do()` returns an error, preventing socket leak.

## Changes

**`resolvers/dns_resolver/dns_resolver.go`**
- `RetrieveIPByARecord`: `result.Answer[0].(*dns.A)` → comma-ok form; returns `NotRetrievedError` if the assertion fails.
- `RetrieveIPByTXTRecord`: `result.Answer[0].(*dns.TXT)` → comma-ok form; same handling.

**`resolvers/stun_resolver/stun_resolver.go`**
- `defer c.Close()` moved from after the `c.Do()` block to immediately after `stun.NewClient` succeeds, so it runs on all exit paths including `c.Do()` failure.

## Validation

- `go build ./...`: no errors
- `go test ./resolvers/dns_resolver/... ./resolvers/stun_resolver/...`: all 13 tests pass
- `go vet ./resolvers/...`: no findings

## Notes

The DNS fix defends against DNS responses that contain CNAME records before the A/TXT record in the `Answer` section — a valid response shape per RFC 1034. The existing tests exercise the success and server-down paths but cannot easily cover the type-mismatch case without a mock DNS server; the change is a direct application of Go's safe assertion idiom with no logic change to the happy path.