### PR TITLE
fix(cmd): select winner deterministically

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -75,16 +75,7 @@ func pickUpFirstItemThatExceededThreshold(siprs []base.ScoredIPRetrievable, time
 		close(c)
 	}()
 	winner := func() (*base.ScoredIP, bool) {
-		if sumOfWeight <= 0 {
-			return nil, false
-		}
-		for ip, score := range m {
-			currentScore := score / sumOfWeight
-			if currentScore > threshold {
-				return &base.ScoredIP{IP: net.ParseIP(ip), Score: currentScore}, true
-			}
-		}
-		return nil, false
+		return pickWinner(m, sumOfWeight, threshold)
 	}
 	for {
 		select {
@@ -107,6 +98,31 @@ func pickUpFirstItemThatExceededThreshold(siprs []base.ScoredIPRetrievable, time
 			}
 		}
 	}
+}
+
+func pickWinner(scores map[string]float64, sumOfWeight float64, threshold float64) (*base.ScoredIP, bool) {
+	if sumOfWeight <= 0 {
+		return nil, false
+	}
+
+	var winnerIP string
+	var winnerScore float64
+	found := false
+	for ip, score := range scores {
+		currentScore := score / sumOfWeight
+		if currentScore <= threshold {
+			continue
+		}
+		if !found || currentScore > winnerScore || currentScore == winnerScore && ip < winnerIP {
+			winnerIP = ip
+			winnerScore = currentScore
+			found = true
+		}
+	}
+	if !found {
+		return nil, false
+	}
+	return &base.ScoredIP{IP: net.ParseIP(winnerIP), Score: winnerScore}, true
 }
 
 var timeout = flag.Duration("timeout", 3*time.Second, "Timeout duration.")

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -62,6 +62,40 @@ func TestPickUpRequiresScoreToExceedThreshold(t *testing.T) {
 	}
 }
 
+func TestPickWinnerChoosesHighestScoreDeterministically(t *testing.T) {
+	scores := map[string]float64{
+		"192.0.2.1": 1.0,
+		"192.0.2.2": 2.0,
+	}
+
+	for i := 0; i < 100; i++ {
+		sip, ok := pickWinner(scores, 3.0, 0.2)
+		if !ok {
+			t.Fatal("expected winner")
+		}
+		if sip.IP.String() != "192.0.2.2" {
+			t.Fatalf("unexpected IP: %s", sip.IP.String())
+		}
+	}
+}
+
+func TestPickWinnerBreaksScoreTiesByIP(t *testing.T) {
+	scores := map[string]float64{
+		"192.0.2.2": 1.0,
+		"192.0.2.1": 1.0,
+	}
+
+	for i := 0; i < 100; i++ {
+		sip, ok := pickWinner(scores, 2.0, 0.2)
+		if !ok {
+			t.Fatal("expected winner")
+		}
+		if sip.IP.String() != "192.0.2.1" {
+			t.Fatalf("unexpected IP: %s", sip.IP.String())
+		}
+	}
+}
+
 func TestPickUpDoesNotPanicOnLateResultAfterWinner(t *testing.T) {
 	retrievers := []base.ScoredIPRetrievable{
 		{IPRetrievable: fakeRetriever{ip: "192.0.2.1", score: 1.0}, Weight: 1.0},


### PR DESCRIPTION
Summary:
- Add deterministic winner selection that chooses the highest normalized score above the threshold.
- Break equal-score ties with the IP string instead of depending on Go map iteration order.
- Add tests for multiple threshold-exceeding candidates and equal-score ties.

Tests:
- go vet ./...
- go test ./...
- go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...
- go build ./...
- git diff --check

Note:
- The GoReleaser cross-build step from CI was not run locally because `goreleaser` is not installed in this environment.
