### PR TITLE
fix(http_resolver): limit HTTP response body reads to 64 bytes

### DIFF
--- a/resolvers/http_resolver/http_resolver.go
+++ b/resolvers/http_resolver/http_resolver.go
@@ -52,7 +52,7 @@ func (p HTTPDetector) RetrieveIPWithContext(ctx context.Context) (*base.ScoredIP
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

`io.ReadAll(resp.Body)` in `resolvers/http_resolver/http_resolver.go` read HTTP response bodies without an upper bound. An IP address string is at most 45 bytes (full IPv6 form), so any response beyond that length is unnecessary allocation.

This change wraps `resp.Body` with `io.LimitReader(resp.Body, 64)` before passing it to `io.ReadAll`. Responses longer than 64 bytes are silently truncated, `net.ParseIP` will reject the result, and `NotRetrievedError` is returned — the same path as any other non-IP response.

## Validation

- `go test ./...` passes with no changes
- `go vet ./...` passes
- `staticcheck ./...` reports one pre-existing issue in `stun_resolver.go` (unrelated)

## Notes

The 64-byte limit is intentionally generous: IPv4 max is 15 bytes, IPv6 max is 45 bytes. The extra headroom absorbs any whitespace added by the server without risking false negatives on valid responses.
