### PR TITLE
fix(cmd): remove dual-parse for --timeout, accept Go duration strings only

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,14 +2,12 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"io"
 
 	"log"
 	"net"
 	"os"
-	"strconv"
 	"sync"
 	"time"
 
@@ -121,12 +119,6 @@ func pickWinner(scores map[string]float64, sumOfWeight float64, threshold float6
 	return &base.ScoredIP{IP: net.ParseIP(winnerIP), Score: winnerScore}, true
 }
 
-var timeout = flag.Duration("timeout", 3*time.Second, "Timeout duration.")
-
-func init() {
-	flag.DurationVar(timeout, "t", 3*time.Second, "Timeout duration.")
-}
-
 func main() {
 
 	usage := `myip
@@ -175,15 +167,9 @@ Options:
 		log.Fatal(err)
 	}
 
-	var duration time.Duration
-	f, err := strconv.ParseFloat(timeoutStr, 64)
+	duration, err := time.ParseDuration(timeoutStr)
 	if err != nil {
-		duration, err = time.ParseDuration(timeoutStr)
-		if err != nil {
-			log.Fatal(err)
-		}
-	} else {
-		duration = time.Duration(f) * time.Second
+		log.Fatal(err)
 	}
 	sip, err := pickUpFirstItemThatExceededThreshold(sir, duration, threshold)
 	if err == nil {


### PR DESCRIPTION
## Summary

The `--timeout` flag had a dual-parse path: plain numbers were silently
treated as seconds, while strings fell through to `time.ParseDuration`.
This made `--timeout=3000` mean 3000 seconds (50 minutes) instead of the
commonly expected 3000 milliseconds, with no indication in the usage text.

Remove the `strconv.ParseFloat` path and accept only Go duration strings
(e.g. `3s`, `500ms`). The default `3s` in the usage already uses this format.
Also remove the dead `flag.Duration` variable and `init()` that were
overridden by docopt and never read.

## Changes

- `cmd/main.go`: remove `flag` and `strconv` imports
- `cmd/main.go`: remove unused `var timeout` and `init()` declarations
- `cmd/main.go`: replace dual-parse with `time.ParseDuration` only

## Validation

- `go build ./...`: OK
- `go test ./...`: all packages pass
- `gofmt`: no changes
- `staticcheck ./...`: 1 pre-existing S1025 in stun_resolver (unrelated)
