### PR TITLE
Add TypeName() to resolvers to remove parallel import paths in cmd

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,23 +15,19 @@ import (
 
 	"github.com/docopt/docopt-go"
 	"github.com/kitsuyui/myip/resolvers/base"
-	"github.com/kitsuyui/myip/resolvers/dns_resolver"
-	"github.com/kitsuyui/myip/resolvers/http_resolver"
-	"github.com/kitsuyui/myip/resolvers/stun_resolver"
 	"github.com/kitsuyui/myip/resolvers/targets"
 )
 
 var version string
 var verboseMode bool
 
+type namer interface {
+	TypeName() string
+}
+
 func typeName(ipr interface{}) string {
-	switch ipr.(type) {
-	case http_resolver.HTTPDetector:
-		return "http"
-	case dns_resolver.DNSDetector:
-		return "dns"
-	case stun_resolver.STUNDetector:
-		return "stun"
+	if n, ok := ipr.(namer); ok {
+		return n.TypeName()
 	}
 	return fmt.Sprintf("%T", ipr)
 }

--- a/resolvers/dns_resolver/dns_resolver.go
+++ b/resolvers/dns_resolver/dns_resolver.go
@@ -82,3 +82,7 @@ func (p DNSDetector) String() string {
 	}
 	return fmt.Sprintf("%s,%s,%s", qt, p.LookupDomainName, p.Resolver)
 }
+
+func (p DNSDetector) TypeName() string {
+	return "dns"
+}

--- a/resolvers/http_resolver/http_resolver.go
+++ b/resolvers/http_resolver/http_resolver.go
@@ -67,3 +67,7 @@ func (p HTTPDetector) RetrieveIPWithContext(ctx context.Context) (*base.ScoredIP
 func (p HTTPDetector) String() string {
 	return p.URL
 }
+
+func (p HTTPDetector) TypeName() string {
+	return "http"
+}

--- a/resolvers/stun_resolver/stun_resolver.go
+++ b/resolvers/stun_resolver/stun_resolver.go
@@ -73,3 +73,7 @@ func (p STUNDetector) RetrieveIP() (*base.ScoredIP, error) {
 func (p STUNDetector) String() string {
 	return fmt.Sprintf("%s", p.Host)
 }
+
+func (p STUNDetector) TypeName() string {
+	return "stun"
+}


### PR DESCRIPTION
## Summary

`cmd/main.go` imported `dns_resolver`, `http_resolver`, and `stun_resolver` both directly (for the `typeName()` type switch) and transitively through `resolvers/targets`. The direct imports existed solely to produce human-readable names in verbose-mode log output.

This PR adds a `TypeName() string` method to each concrete resolver type (`DNSDetector`, `HTTPDetector`, `STUNDetector`) and replaces the type-switch in `cmd/main.go` with a duck-type check against a local `namer` interface. `cmd/main.go` no longer imports the three resolver packages directly; it reaches them only through `resolvers/targets`.

## Changes

- `resolvers/dns_resolver/dns_resolver.go`: add `TypeName() string` → `"dns"`
- `resolvers/http_resolver/http_resolver.go`: add `TypeName() string` → `"http"`
- `resolvers/stun_resolver/stun_resolver.go`: add `TypeName() string` → `"stun"`
- `cmd/main.go`: remove direct resolver imports; replace type switch with `namer` interface check

## Behavior

- Verbose-mode log output (`type:dns`, `type:http`, `type:stun`) is unchanged for existing resolvers
- Future resolvers that implement `TypeName()` automatically appear with their chosen name
- Resolvers that do not implement `TypeName()` fall back to `fmt.Sprintf("%T", ipr)` (same as before for unknown types)
- All existing tests pass

## Validation

- `go build ./...`: no errors
- `go test ./cmd/... ./resolvers/...`: all pass
- `gofmt -l .`: no unformatted files
- `staticcheck ./...`: one pre-existing S1025 in `stun_resolver.String()` (not in scope for this PR)
