### PR TITLE
fix(stun_resolver): close conn when stun.NewClient fails

### DIFF
--- a/resolvers/stun_resolver/stun_resolver.go
+++ b/resolvers/stun_resolver/stun_resolver.go
@@ -5,7 +5,6 @@ package stun_resolver
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net"
 	"strconv"
 
@@ -45,6 +44,7 @@ func (p STUNDetector) RetrieveIP() (*base.ScoredIP, error) {
 	}
 	c, err := stun.NewClient(conn)
 	if err != nil {
+		conn.Close()
 		return nil, &base.NotRetrievedError{}
 	}
 	var err2 error
@@ -71,5 +71,5 @@ func (p STUNDetector) RetrieveIP() (*base.ScoredIP, error) {
 }
 
 func (p STUNDetector) String() string {
-	return fmt.Sprintf("%s", p.Host)
+	return p.Host
 }


### PR DESCRIPTION
## Summary

- Add `conn.Close()` in the `stun.NewClient` error path so the underlying network connection is always released when `NewClient` fails.
- Remove the redundant `fmt.Sprintf("%s", p.Host)` in `String()` (staticcheck S1025) and drop the now-unused `fmt` import.

## Problem

`stun.NewClient(conn)` wraps the provided `net.Conn`. If it returns an error, the original `conn` is not closed, leaving a TCP or TLS connection open. With 30+ STUN targets running concurrently ([`resolvers/targets/targets.go`](resolvers/targets/targets.go)), repeated failures can accumulate unclosed file descriptors.

Note: the related issue where `defer c.Close()` was placed after `c.Do()` (meaning it was skipped on `c.Do` failure) is addressed in the open PR #312.

## Changes

**`resolvers/stun_resolver/stun_resolver.go`**
- `stun.NewClient` error path: `conn.Close()` added before return.
- `String()`: simplified `fmt.Sprintf("%s", p.Host)` → `p.Host`.
- Removed unused `fmt` import.

## Validation

- `go build ./...`: no errors
- `go test ./resolvers/stun_resolver/...`: all 6 tests pass
- `go vet ./...`: no findings
- `staticcheck ./...`: no findings (S1025 resolved)