### PR TITLE
fix(targets): include dual-stack resolvers in IPv4 mode

### DIFF
--- a/resolvers/targets/targets.go
+++ b/resolvers/targets/targets.go
@@ -71,7 +71,7 @@ func IPRetrievables() []base.ScoredIPRetrievable {
 
 func IPv4Retrievables() (sir []base.ScoredIPRetrievable) {
 	for _, sipr := range IPRetrievables() {
-		if sipr.IPv4 && !sipr.IPv6 {
+		if sipr.IPv4 {
 			sir = append(sir, sipr)
 		}
 	}


### PR DESCRIPTION
## Summary

`IPv4Retrievables()` filtered with `IPv4 && !IPv6`, silently dropping resolvers that support both address families. Several targets (e.g. `icanhazip.com`, `wgetip.com`, `ifconfig.io`, and the Google DNS TXT resolver) have `IPv4: true, IPv6: true` and were excluded from the `-4` candidate pool.

The README describes `-4` as preferring IPv4, not restricting to IPv4-only endpoints. Excluding dual-stack resolvers reduces redundancy and success rate without matching user expectations.

## Change

`resolvers/targets/targets.go`: change `IPv4Retrievables()` filter from `sipr.IPv4 && !sipr.IPv6` to `sipr.IPv4`.

## Validation

- `go build ./...` passes
- `go vet ./...` passes
- `staticcheck ./resolvers/targets/...` passes (0 findings)

## Notes

`IPv6Retrievables()` already uses `sipr.IPv6` (no negation), so it correctly includes dual-stack targets. This change makes `IPv4Retrievables()` symmetric.