### PR TITLE
fix(http_resolver): cap response header size via MaxResponseHeaderBytes

### DIFF
--- a/resolvers/http_resolver/http_resolver.go
+++ b/resolvers/http_resolver/http_resolver.go
@@ -46,7 +46,9 @@ func (p HTTPDetector) RetrieveIPWithContext(ctx context.Context) (*base.ScoredIP
 	if err != nil {
 		return nil, err
 	}
-	client := http.Client{}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxResponseHeaderBytes = 4096
+	client := http.Client{Transport: transport}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- Clone `http.DefaultTransport` and set `MaxResponseHeaderBytes: 4096` to explicitly cap the response header size at the trust boundary.
- The body is already limited to 64 bytes via `io.LimitReader`; this change adds the same explicit bound for response headers.
- Cloning `DefaultTransport` (rather than using a bare `&http.Transport{}`) preserves TLS handshake timeouts, proxy settings, and connection-pool defaults.

## Validation
- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` — all packages pass
- `staticcheck ./...` — no findings

## Notes
- 4 KiB is sufficient for any legitimate IP-lookup service response header; the limit prevents a compromised endpoint from exhausting memory via oversized headers.
