### PR TITLE
fix: use git tag version for release builds instead of snapshot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --snapshot --clean
+          args: ${{ github.event_name == 'pull_request' && 'release --snapshot --clean' || 'release --clean' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Remove `--snapshot` flag from goreleaser when building on actual release events
- `--snapshot` is now only passed for `pull_request` builds (CI dry-runs)
- Release events (`prereleased`, `released`) now build using the git tag version, so `myip --version` returns the actual release tag

Previously, `--snapshot` was always passed regardless of trigger. In snapshot mode goreleaser uses `snapshot.name_template` (`{{ incpatch .Version }}-next`), causing release binaries to report `v1.0.1-next` instead of the real tag `v1.0.0`.

## Validation

- `go fmt ./...` — no changes
- `go vet ./...` — no issues
- `go test ./...` — all tests pass
- `staticcheck ./...` — 0 findings

## Notes

Uses a GitHub Actions expression to select args conditionally:
```
${{ github.event_name == 'pull_request' && 'release --snapshot --clean' || 'release --clean' }}
```
goreleaser resolves the version from the annotated git tag automatically when `--snapshot` is omitted.