### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,23 @@ $ go mod download
 $ go build ./...
 ```
 
+## Development
+
+This project uses [lefthook](https://github.com/evilmartians/lefthook) to run the same checks as CI locally.
+
+### Setup
+
+```console
+$ lefthook install
+```
+
+### Hooks
+
+- **pre-commit**: runs `go vet ./...` to catch issues before each commit.
+- **pre-push**: runs `go vet ./...` and `go test ./...` before each push.
+
+CI still runs the full suite on every pull request and push to main — the hooks bring that feedback earlier, to your local machine.
+
 ## LICENSE
 
 ### Source

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: vet
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; go vet ./...
+
+pre-push:
+  jobs:
+    - name: vet
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; go vet ./...
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; go test ./...


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` with a `pre-commit` hook (`go vet ./...`) and a `pre-push` hook (`go vet ./...` + `go test ./...`), mirroring the `golang-test` CI checks locally.
- Add a `## Development` section to `README.md` documenting `lefthook install` and what each hook does.
- CI workflows are untouched; the hooks bring the same feedback earlier, before a push reaches CI.

## Changed files

- `lefthook.yml` (new)
- `README.md` (added Development section before LICENSE)
