### PR TITLE
docs: add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report a problem with myip
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## Steps to reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include error messages or output if applicable.
+
+## Environment
+
+- OS: [e.g. macOS 14]
+- Go version: [e.g. 1.24]
+- myip version: [e.g. v1.2.3 or main at abc1234]
+- Network setup: [e.g. VPN, proxy]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a new resolver or feature for myip
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+Describe the problem or limitation this feature would address.
+
+## Proposed solution
+
+Describe what you'd like to happen.
+
+## Alternatives considered
+
+Describe any alternative solutions you've considered.
+
+## Additional context
+
+Any other context (links to resolver services, protocols, etc.).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- Describe the motivation and what this PR changes. -->
+
+## Changes
+
+<!-- List the main changes made. -->
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] `go vet ./...` passes locally
+- [ ] `go test ./...` passes locally
+- [ ] Documentation updated (if applicable)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported via [GitHub's private vulnerability reporting](https://github.com/kitsuyui/myip/security/advisories/new) or by opening an issue.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thank you for your interest in contributing to myip!
+
+## Getting Started
+
+1. Fork the repository and clone your fork.
+2. Install Go (see `go.mod` for the required version).
+3. Run the tests to verify your setup:
+   ```sh
+   go test ./...
+   ```
+
+## Making Changes
+
+- Open an issue to discuss significant changes before starting work.
+- Keep pull requests focused on a single concern.
+- Add tests for any new or changed behavior.
+- Run `go vet ./...` and `go test ./...` locally before submitting.
+
+## Pull Request Process
+
+1. Create a branch from `main` with a descriptive name (e.g. `fix/issue-description`).
+2. Write a clear PR title and description explaining the motivation and scope.
+3. Ensure all CI checks pass.
+4. A maintainer will review and merge your PR.
+
+## Reporting Bugs
+
+Please open a [GitHub Issue](https://github.com/kitsuyui/myip/issues/new/choose) with:
+- A clear description of the problem
+- Steps to reproduce
+- Expected vs. actual behavior
+- Environment details (OS, Go version, myip version)
+
+## Security Vulnerabilities
+
+See [SECURITY.md](SECURITY.md) for how to report security issues privately.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+To report a security issue privately, use [GitHub's private vulnerability reporting](https://github.com/kitsuyui/myip/security/advisories/new).
+
+Include as much of the following information as possible:
+- Type of issue (e.g. DNS poisoning, MITM, information leak)
+- Affected component and version
+- Steps to reproduce
+- Potential impact
+
+You will receive a response within 7 days. We aim to release a fix within 30 days of confirmation.
+
+## Supported Versions
+
+Only the latest release is actively supported with security fixes.


### PR DESCRIPTION
## Summary

Add community health files to provide contributor guidance that was previously missing.

- `CONTRIBUTING.md`: setup steps, development workflow, PR process, and bug reporting guidelines
- `SECURITY.md`: private vulnerability disclosure via GitHub security advisories
- `CODE_OF_CONDUCT.md`: Contributor Covenant v2.1
- `.github/ISSUE_TEMPLATE/bug_report.md`: structured bug report form
- `.github/ISSUE_TEMPLATE/feature_request.md`: feature request form
- `.github/pull_request_template.md`: PR checklist

## Motivation

Without these files, external contributors have no guidance on how to submit PRs,
report bugs with the necessary context, or disclose security vulnerabilities privately.
The GitHub Community Health score was at 42% due to these missing files.

## Verification

- All existing tests pass (`go test ./...`)
- `go vet ./...` reports 0 issues
- `staticcheck ./...` reports 0 findings
- No changes to existing code — new files only