### PR TITLE
Add govulncheck security scan workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -31,3 +31,5 @@ jobs:
 
       - name: govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1
+        with:
+          repo-checkout: 'false'

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,33 @@
+name: Security Audit
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 3 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: ^1.19.4
+          check-latest: true
+
+      - name: govulncheck
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1


### PR DESCRIPTION
## Summary

Add a dedicated `govulncheck.yml` workflow that runs `govulncheck` to scan Go module dependencies for known vulnerabilities using the Go vulnerability database.

## Changes

- New `.github/workflows/govulncheck.yml` with:
  - Triggers: `push` (main), `pull_request`, `schedule` (weekly Monday 03:00 UTC)
  - SHA-pinned action refs for supply-chain integrity
  - Uses `golang/govulncheck-action@v1` (official Go vulnerability scanner action)

## Problem addressed

The CI pipeline had no automated check for known CVEs in Go dependencies. The `renovate.json5` config uses only `config:base` without `osvVulnerabilityAlerts: true`, so Renovate does not raise vulnerability alerts automatically. Dependencies such as the archived `gortc.io/stun` (now `github.com/pion/stun`) carry advisory risk without automated CI detection.

Adding `govulncheck` reduces the detection window between CVE publication and developer awareness.

## Validation

- YAML syntax: valid
- actionlint: 0 findings
- collateral check: clean
- Scope: workflow file only, no Go source changes