### PR TITLE
fix(resolvers): rename packages to remove underscores per Go naming conventions

### DIFF
--- a/resolvers/dns_resolver/dns_resolver.go
+++ b/resolvers/dns_resolver/dns_resolver.go
@@ -1,6 +1,6 @@
 // DNS Resolver
 // Resolve IP address by DNS query
-package dns_resolver
+package dnsresolver
 
 import (
 	"fmt"

--- a/resolvers/dns_resolver/dns_resolver_test.go
+++ b/resolvers/dns_resolver/dns_resolver_test.go
@@ -1,4 +1,4 @@
-package dns_resolver
+package dnsresolver
 
 import (
 	"testing"

--- a/resolvers/http_resolver/http_resolver.go
+++ b/resolvers/http_resolver/http_resolver.go
@@ -1,6 +1,6 @@
 // HTTP resolver
 // Detect IP address by HTTP / HTTPS response
-package http_resolver
+package httpresolver
 
 import (
 	"context"

--- a/resolvers/http_resolver/http_resolver_test.go
+++ b/resolvers/http_resolver/http_resolver_test.go
@@ -1,4 +1,4 @@
-package http_resolver
+package httpresolver
 
 import (
 	"context"

--- a/resolvers/stun_resolver/stun_resolver.go
+++ b/resolvers/stun_resolver/stun_resolver.go
@@ -1,7 +1,7 @@
 // STUN Resolver
 // Resolve IP address by STUN protocol
 // c.f. https://en.wikipedia.org/wiki/STUN
-package stun_resolver
+package stunresolver
 
 import (
 	"crypto/tls"

--- a/resolvers/stun_resolver/stun_resolver_test.go
+++ b/resolvers/stun_resolver/stun_resolver_test.go
@@ -1,4 +1,4 @@
-package stun_resolver
+package stunresolver
 
 import (
 	"context"

--- a/resolvers/targets/targets.go
+++ b/resolvers/targets/targets.go
@@ -9,9 +9,9 @@ import (
 
 func IPRetrievables() []base.ScoredIPRetrievable {
 	type scored = base.ScoredIPRetrievable
-	type http = http_resolver.HTTPDetector
-	type dns = dns_resolver.DNSDetector
-	type stun = stun_resolver.STUNDetector
+	type http = httpresolver.HTTPDetector
+	type dns = dnsresolver.DNSDetector
+	type stun = stunresolver.STUNDetector
 	return []base.ScoredIPRetrievable{
 		scored{IPRetrievable: http{URL: "http://inet-ip.info/ip"}, Weight: 1.0, IPv4: true, IPv6: false},
 		scored{IPRetrievable: http{URL: "http://whatismyip.akamai.com/"}, Weight: 1.0, IPv4: true, IPv6: false},


### PR DESCRIPTION
## Summary

Three packages under `resolvers/` used underscores in their package names,
which violates Go naming conventions ([Effective Go: package names](https://golang.org/doc/effective_go#package-names))
and triggers `golint`/`staticcheck` warnings (`don't use underscores in package name`).
The sibling packages `base` and `targets` already follow the correct convention.

| Directory | Before | After |
|---|---|---|
| `resolvers/dns_resolver/` | `package dns_resolver` | `package dnsresolver` |
| `resolvers/http_resolver/` | `package http_resolver` | `package httpresolver` |
| `resolvers/stun_resolver/` | `package stun_resolver` | `package stunresolver` |

`targets/targets.go` type aliases are updated to use the new package identifiers.
Import paths (directory names) are unchanged.

## Validation

- `go build ./...` — passes
- `go vet ./...` — passes
- `go fmt ./...` — no changes
- `staticcheck ./...` — no findings

## Notes

Directory names (`dns_resolver/`, `http_resolver/`, `stun_resolver/`) are kept as-is.
Renaming directories to match the package names would be a follow-up cleanup.
