### PR TITLE
Validate threshold input before resolver selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Options:
  -6 --ipv6               						 Prefer IPv6.
  -n --newline            						 Show IP with newline.
  -N --no-newline         						 Show IP without newline.
- -T=<rate> --threshold=<rate>  			 Threshold that must be exceeded by weighted votes [default: 0.6].
+ -T=<rate> --threshold=<rate>  			 Threshold in [0.0, 1.0] that must be exceeded by weighted votes [default: 0.6].
  -t=<duration> --timeout=<duration>  Timeout [default: 3s].
 ```
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 
 	"log"
 	"net"
@@ -28,6 +29,13 @@ func typeName(ipr interface{}) string {
 		return n.TypeName()
 	}
 	return fmt.Sprintf("%T", ipr)
+}
+
+func validateThreshold(threshold float64) error {
+	if math.IsNaN(threshold) || math.IsInf(threshold, 0) || threshold < 0 || threshold > 1 {
+		return fmt.Errorf("threshold must be between 0 and 1")
+	}
+	return nil
 }
 
 func pickUpFirstItemThatExceededThreshold(siprs []base.ScoredIPRetrievable, timeout time.Duration, threshold float64) (*base.ScoredIP, error) {
@@ -135,7 +143,7 @@ Options:
  -6 --ipv6               						 Prefer IPv6.
  -n --newline            						 Show IP with newline.
  -N --no-newline         						 Show IP without newline.
- -T=<rate> --threshold=<rate>  			 Threshold that must be exceeded by weighted votes [default: 0.6].
+ -T=<rate> --threshold=<rate>  			 Threshold in [0.0, 1.0] that must be exceeded by weighted votes [default: 0.6].
  -t=<duration> --timeout=<duration>  Timeout [default: 3s].
 `
 	opts, err := docopt.ParseDoc(usage)
@@ -159,6 +167,9 @@ Options:
 	}
 	threshold, err := opts.Float64("--threshold")
 	if err != nil {
+		log.Fatal(err)
+	}
+	if err := validateThreshold(threshold); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math"
 	"net"
 	"testing"
 	"time"
@@ -59,6 +60,32 @@ func TestPickUpRequiresScoreToExceedThreshold(t *testing.T) {
 	}
 	if _, ok := err.(*base.NotRetrievedError); !ok {
 		t.Fatalf("expected NotRetrievedError, got %T", err)
+	}
+}
+
+func TestValidateThreshold(t *testing.T) {
+	cases := []struct {
+		name      string
+		threshold float64
+		wantErr   bool
+	}{
+		{name: "below range", threshold: -0.01, wantErr: true},
+		{name: "above range", threshold: 1.01, wantErr: true},
+		{name: "minimum boundary", threshold: 0, wantErr: false},
+		{name: "maximum boundary", threshold: 1, wantErr: false},
+		{name: "nan threshold", threshold: math.NaN(), wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateThreshold(tc.threshold)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for threshold %v", tc.threshold)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("did not expect error for threshold %v: %v", tc.threshold, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Validate threshold input before resolver selection

Reject out-of-range `--threshold` values before any resolver lookup, then
keep weighted voting behavior unchanged for valid inputs. Update the CLI usage
text and README threshold description to match the documented `[0.0, 1.0]`
contract.

## Chosen fix

- approach: surface-cli-threshold-range-validation
The finding is about a single public CLI option accepting invalid input and
producing surprising runtime semantics. A surface fix at the option parsing
boundary removes the unsafe behavior without changing resolver scoring,
concurrency, or weighting design. This stays within repo-policy because it
does not touch repository settings, administration workflows, or supported
runtime versions.