### PR TITLE
test(resolvers): cover DNS and STUN success paths in short mode

### DIFF
--- a/resolvers/dns_resolver/dns_resolver_test.go
+++ b/resolvers/dns_resolver/dns_resolver_test.go
@@ -1,19 +1,27 @@
 package dnsresolver
 
 import (
+	"net"
 	"testing"
+
+	"github.com/miekg/dns"
 )
 
 func TestDNSARecordSuccess(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping live network test in short mode")
-	}
-	d := DNSDetector{LookupDomainName: "myip.opendns.com.", Resolver: "208.67.222.222:53"}
+	server := startTestDNSServer(t, func(req *dns.Msg) []dns.RR {
+		return []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{Name: req.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+				A:   net.ParseIP("203.0.113.10").To4(),
+			},
+		}
+	})
+	d := DNSDetector{LookupDomainName: "example.test.", Resolver: server}
 	ip, err := d.RetrieveIP()
 	if err != nil {
 		t.Errorf("DNS A Record Query should be succeed")
 	}
-	if ip == nil {
+	if ip == nil || !ip.IP.Equal(net.ParseIP("203.0.113.10")) {
 		t.Errorf("IP must not nil")
 	}
 }
@@ -30,10 +38,10 @@ func TestDNSARecordFailWhenDNSServerIsDownOrNotExists(t *testing.T) {
 }
 
 func TestDNSARecordFailWhenInvalidLookup(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping live network test in short mode")
-	}
-	d := DNSDetector{LookupDomainName: "dummy.opendns.com.", Resolver: "resolver1.opendns.com:53"}
+	server := startTestDNSServer(t, func(req *dns.Msg) []dns.RR {
+		return nil
+	})
+	d := DNSDetector{LookupDomainName: "missing.example.test.", Resolver: server}
 	ip, err := d.RetrieveIP()
 	if err == nil {
 		t.Errorf("This should be error")
@@ -44,15 +52,20 @@ func TestDNSARecordFailWhenInvalidLookup(t *testing.T) {
 }
 
 func TestDNSTXTRecordSuccess(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping live network test in short mode")
-	}
-	d := DNSDetector{LookupDomainName: "o-o.myaddr.l.google.com.", Resolver: "ns1.google.com:53", QueryType: "TXT"}
+	server := startTestDNSServer(t, func(req *dns.Msg) []dns.RR {
+		return []dns.RR{
+			&dns.TXT{
+				Hdr: dns.RR_Header{Name: req.Question[0].Name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 60},
+				Txt: []string{"2001:db8::5"},
+			},
+		}
+	})
+	d := DNSDetector{LookupDomainName: "txt.example.test.", Resolver: server, QueryType: "TXT"}
 	ip, err := d.RetrieveIP()
 	if err != nil {
 		t.Errorf("DNS TXT Record Query should be succeed.")
 	}
-	if ip == nil {
+	if ip == nil || !ip.IP.Equal(net.ParseIP("2001:db8::5")) {
 		t.Errorf("IP must not nil")
 	}
 }
@@ -69,10 +82,10 @@ func TestDNSTXTRecordFailWhenDNSServerIsDownOrNotExists(t *testing.T) {
 }
 
 func TestDNSTXTRecordFailWhenInvalidLookup(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping live network test in short mode")
-	}
-	d := DNSDetector{LookupDomainName: "dummy.myaddr.l.google.com.", Resolver: "ns1.google.com:53", QueryType: "TXT"}
+	server := startTestDNSServer(t, func(req *dns.Msg) []dns.RR {
+		return nil
+	})
+	d := DNSDetector{LookupDomainName: "missing-txt.example.test.", Resolver: server, QueryType: "TXT"}
 	ip, err := d.RetrieveIP()
 	if err == nil {
 		t.Errorf("This should be error")
@@ -103,4 +116,39 @@ func TestGetString(t *testing.T) {
 	if result != tobe {
 		t.Errorf("The result must be %s", tobe)
 	}
+}
+
+func startTestDNSServer(t *testing.T, answer func(req *dns.Msg) []dns.RR) string {
+	t.Helper()
+
+	packetConn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen udp: %v", err)
+	}
+
+	server := &dns.Server{
+		PacketConn: packetConn,
+		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, req *dns.Msg) {
+			msg := new(dns.Msg)
+			msg.SetReply(req)
+			msg.Answer = answer(req)
+			if err := w.WriteMsg(msg); err != nil {
+				t.Errorf("write dns response: %v", err)
+			}
+		}),
+	}
+
+	go func() {
+		if err := server.ActivateAndServe(); err != nil {
+			t.Logf("dns server stopped: %v", err)
+		}
+	}()
+
+	t.Cleanup(func() {
+		if err := server.Shutdown(); err != nil {
+			t.Errorf("shutdown dns server: %v", err)
+		}
+	})
+
+	return packetConn.LocalAddr().String()
 }

--- a/resolvers/stun_resolver/stun_resolver.go
+++ b/resolvers/stun_resolver/stun_resolver.go
@@ -17,6 +17,12 @@ import (
 // cannot outlive the caller's context deadline by more than this duration.
 const dialTimeout = 5 * time.Second
 
+var tlsConfigForHost = func(host string) *tls.Config {
+	return &tls.Config{
+		ServerName: host,
+	}
+}
+
 type STUNDetector struct {
 	Host     string `json:"host"`
 	Protocol string `json:"protocol"`
@@ -35,9 +41,7 @@ func (p STUNDetector) RetrieveIP() (*base.ScoredIP, error) {
 	address := uri.Host + ":" + strconv.Itoa(uri.Port)
 	dialer := &net.Dialer{Timeout: dialTimeout}
 	if scheme == stun.SchemeTypeSTUNS {
-		cfg := &tls.Config{
-			ServerName: uri.Host,
-		}
+		cfg := tlsConfigForHost(uri.Host)
 		conn, err = tls.DialWithDialer(dialer, p.Protocol, address, cfg)
 		if err != nil {
 			return nil, &base.NotRetrievedError{}

--- a/resolvers/stun_resolver/stun_resolver_test.go
+++ b/resolvers/stun_resolver/stun_resolver_test.go
@@ -2,37 +2,52 @@ package stunresolver
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/kitsuyui/myip/resolvers/base"
+	"github.com/pion/stun"
 )
 
 func TestSTUNSuccess(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping live network test in short mode")
-	}
-	h := STUNDetector{Host: "stun:stun.cloudflare.com:3478", Protocol: "udp"}
+	serverAddr := startTestUDPSTUNServer(t, net.ParseIP("203.0.113.20"))
+	h := STUNDetector{Host: "stun:" + serverAddr, Protocol: "udp"}
 	ip, err := h.RetrieveIP()
 	if err != nil {
 		t.Errorf("Should be succeed")
 	}
-	if ip == nil {
+	if ip == nil || !ip.IP.Equal(net.ParseIP("203.0.113.20")) || ip.Score != 0.1 {
 		t.Errorf("IP must not nil")
 	}
 }
 
 func TestSTUNSSuccess(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping live network test in short mode")
+	serverName, serverAddr, pool := startTestTLSSTUNServer(t, net.ParseIP("2001:db8::7"))
+	originalTLSConfigForHost := tlsConfigForHost
+	tlsConfigForHost = func(host string) *tls.Config {
+		cfg := originalTLSConfigForHost(host)
+		cfg.RootCAs = pool
+		return cfg
 	}
-	h := STUNDetector{Host: "stuns:turn.cloudflare.com:5349", Protocol: "tcp"}
+	t.Cleanup(func() {
+		tlsConfigForHost = originalTLSConfigForHost
+	})
+
+	h := STUNDetector{Host: fmt.Sprintf("stuns:%s:%s", serverName, serverAddr.Port()), Protocol: "tcp"}
 	ip, err := h.RetrieveIP()
 	if err != nil {
 		t.Errorf("Should be succeed")
 	}
-	if ip == nil {
+	if ip == nil || !ip.IP.Equal(net.ParseIP("2001:db8::7")) || ip.Score != 1.0 {
 		t.Errorf("IP must not nil")
 	}
 }
@@ -105,4 +120,164 @@ func TestGetString(t *testing.T) {
 	if result != tobe {
 		t.Errorf("The result must be %s", tobe)
 	}
+}
+
+func startTestUDPSTUNServer(t *testing.T, responseIP net.IP) string {
+	t.Helper()
+
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen udp: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Close(); err != nil {
+			t.Errorf("close udp listener: %v", err)
+		}
+	})
+
+	go handleSTUNPacketConn(t, conn, responseIP)
+
+	return conn.LocalAddr().String()
+}
+
+func startTestTLSSTUNServer(t *testing.T, responseIP net.IP) (string, testHostPort, *x509.CertPool) {
+	t.Helper()
+
+	serverName := "localhost"
+	certificate, pool := mustCreateTestCertificate(t, serverName)
+	listener, err := tls.Listen("tcp", net.JoinHostPort(serverName, "0"), &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+	})
+	if err != nil {
+		t.Fatalf("listen tls: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := listener.Close(); err != nil {
+			t.Errorf("close tls listener: %v", err)
+		}
+	})
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go handleSTUNTCPConn(t, conn, responseIP)
+		}
+	}()
+
+	return serverName, testHostPort(listener.Addr().String()), pool
+}
+
+type testHostPort string
+
+func (p testHostPort) Port() string {
+	_, port, err := net.SplitHostPort(string(p))
+	if err != nil {
+		return ""
+	}
+	return port
+}
+
+func handleSTUNPacketConn(t *testing.T, conn net.PacketConn, responseIP net.IP) {
+	t.Helper()
+
+	buffer := make([]byte, 1500)
+	for {
+		n, addr, err := conn.ReadFrom(buffer)
+		if err != nil {
+			return
+		}
+		response, err := buildSTUNSuccessResponse(buffer[:n], responseIP)
+		if err != nil {
+			t.Errorf("build STUN response: %v", err)
+			return
+		}
+		if _, err := conn.WriteTo(response, addr); err != nil {
+			t.Errorf("write STUN response: %v", err)
+			return
+		}
+	}
+}
+
+func handleSTUNTCPConn(t *testing.T, conn net.Conn, responseIP net.IP) {
+	t.Helper()
+	defer conn.Close()
+
+	if err := conn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Errorf("set deadline: %v", err)
+		return
+	}
+
+	buffer := make([]byte, 1500)
+	n, err := conn.Read(buffer)
+	if err != nil {
+		t.Errorf("read STUN request: %v", err)
+		return
+	}
+
+	response, err := buildSTUNSuccessResponse(buffer[:n], responseIP)
+	if err != nil {
+		t.Errorf("build STUN response: %v", err)
+		return
+	}
+
+	if _, err := conn.Write(response); err != nil {
+		t.Errorf("write STUN response: %v", err)
+	}
+}
+
+func buildSTUNSuccessResponse(rawRequest []byte, responseIP net.IP) ([]byte, error) {
+	var request stun.Message
+	request.Raw = append([]byte(nil), rawRequest...)
+	if err := request.Decode(); err != nil {
+		return nil, err
+	}
+
+	response := stun.MustBuild(
+		stun.NewTransactionIDSetter(request.TransactionID),
+		stun.BindingSuccess,
+		&stun.XORMappedAddress{IP: responseIP, Port: 3478},
+	)
+	return response.Raw, nil
+}
+
+func mustCreateTestCertificate(t *testing.T, serverName string) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate private key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: serverName,
+		},
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(time.Hour),
+		KeyUsage:  x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+		},
+		DNSNames: []string{serverName},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+
+	certificatePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+	certificate, err := tls.X509KeyPair(certificatePEM, keyPEM)
+	if err != nil {
+		t.Fatalf("parse certificate: %v", err)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(certificatePEM)
+	return certificate, pool
 }


### PR DESCRIPTION
## Summary

Make the default short-mode CI exercise the DNS and STUN success paths that `myip` uses in normal operation.

## Changes

- replace live-network DNS success tests with a local in-process DNS server
- replace live-network STUN and STUNS success tests with local UDP and TLS responders
- add a package-private TLS config seam so the STUNS test can trust a local certificate without changing runtime defaults

## Checklist

- [x] Tests added or updated
- [x] `go vet ./...` passes locally
- [x] `go test ./...` passes locally
- [ ] Documentation updated (if applicable)
