### PR TITLE
fix(cmd): remove the redundant newline flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,6 @@ $ myip
 203.0.113.2
 ```
 
-## Output with newline by (`-n` or `--newline`) option
-
-This option gives output with ending newline character.
-
-```console
-$ myip
-203.0.113.2$
-```
-
-```console
-$ myip -n
-203.0.113.2
-$
-```
-
 ## Version
 
 ```console
@@ -84,7 +69,7 @@ $ myip -h
 myip
 
 Usage:
- myip [-v | --verbose] [-4 | -6] [-T=<rate>] [-t=<duration>]
+ myip [-v | --verbose] [-4 | -6] [-N | --no-newline] [-T=<rate>] [-t=<duration>]
  myip (--help | --version)
 
 Options:
@@ -93,7 +78,6 @@ Options:
  -v --verbose            						 Verbose mode.
  -4 --ipv4               						 Prefer IPv4.
  -6 --ipv6               						 Prefer IPv6.
- -n --newline            						 Show IP with newline.
  -N --no-newline         						 Show IP without newline.
  -T=<rate> --threshold=<rate>  			 Threshold in [0.0, 1.0] that must be exceeded by weighted votes [default: 0.6].
  -t=<duration> --timeout=<duration>  Timeout [default: 3s].

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,23 @@ import (
 var version string
 var verboseMode bool
 
+const usageText = `myip
+
+Usage:
+ myip [-v | --verbose] [-4 | -6] [-N | --no-newline] [-T=<rate>] [-t=<duration>]
+ myip (--help | --version)
+
+Options:
+ -h --help               						 Show this screen.
+ -V --version            						 Show version.
+ -v --verbose            						 Verbose mode.
+ -4 --ipv4               						 Prefer IPv4.
+ -6 --ipv6               						 Prefer IPv6.
+ -N --no-newline         						 Show IP without newline.
+ -T=<rate> --threshold=<rate>  			 Threshold in [0.0, 1.0] that must be exceeded by weighted votes [default: 0.6].
+ -t=<duration> --timeout=<duration>  Timeout [default: 3s].
+`
+
 type namer interface {
 	TypeName() string
 }
@@ -127,26 +144,17 @@ func pickWinner(scores map[string]float64, sumOfWeight float64, threshold float6
 	return &base.ScoredIP{IP: net.ParseIP(winnerIP), Score: winnerScore}, true
 }
 
+func writeIP(out io.Writer, ip string, noNewline bool) error {
+	if noNewline {
+		_, err := fmt.Fprint(out, ip)
+		return err
+	}
+	_, err := fmt.Fprintln(out, ip)
+	return err
+}
+
 func main() {
-
-	usage := `myip
-
-Usage:
- myip [-v | --verbose] [-4 | -6] [-T=<rate>] [-t=<duration>]
- myip (--help | --version)
-
-Options:
- -h --help               						 Show this screen.
- -V --version            						 Show version.
- -v --verbose            						 Verbose mode.
- -4 --ipv4               						 Prefer IPv4.
- -6 --ipv6               						 Prefer IPv6.
- -n --newline            						 Show IP with newline.
- -N --no-newline         						 Show IP without newline.
- -T=<rate> --threshold=<rate>  			 Threshold in [0.0, 1.0] that must be exceeded by weighted votes [default: 0.6].
- -t=<duration> --timeout=<duration>  Timeout [default: 3s].
-`
-	opts, err := docopt.ParseDoc(usage)
+	opts, err := docopt.ParseDoc(usageText)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -185,9 +193,13 @@ Options:
 	sip, err := pickUpFirstItemThatExceededThreshold(sir, duration, threshold)
 	if err == nil {
 		if noNewline, _ := opts.Bool("--no-newline"); noNewline {
-			fmt.Print(sip.IP.String())
+			if err := writeIP(os.Stdout, sip.IP.String(), true); err != nil {
+				log.Fatal(err)
+			}
 		} else {
-			fmt.Println(sip.IP.String())
+			if err := writeIP(os.Stdout, sip.IP.String(), false); err != nil {
+				log.Fatal(err)
+			}
 		}
 	} else {
 		if err != nil {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"math"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -137,4 +139,35 @@ func TestPickUpDoesNotPanicOnLateResultAfterWinner(t *testing.T) {
 	}
 
 	time.Sleep(50 * time.Millisecond)
+}
+
+func TestUsageTextDoesNotExposeRedundantNewlineFlag(t *testing.T) {
+	if strings.Contains(usageText, "--newline") {
+		t.Fatalf("usage text must not expose redundant newline flag: %q", usageText)
+	}
+	if !strings.Contains(usageText, "--no-newline") {
+		t.Fatalf("usage text must expose no-newline flag: %q", usageText)
+	}
+}
+
+func TestWriteIP(t *testing.T) {
+	t.Run("default output ends with newline", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := writeIP(&buf, "192.0.2.1", false); err != nil {
+			t.Fatalf("writeIP returned error: %v", err)
+		}
+		if got := buf.String(); got != "192.0.2.1\n" {
+			t.Fatalf("unexpected output: %q", got)
+		}
+	})
+
+	t.Run("no-newline output omits trailing newline", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := writeIP(&buf, "192.0.2.1", true); err != nil {
+			t.Fatalf("writeIP returned error: %v", err)
+		}
+		if got := buf.String(); got != "192.0.2.1" {
+			t.Fatalf("unexpected output: %q", got)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- remove the redundant `-n` / `--newline` CLI flag from the public help and README

- keep the default trailing newline behavior and retain `--no-newline` as the explicit opt-out
- add tests that lock the remaining CLI output contract
## Changes

- move the CLI usage text into a shared constant and stop advertising `--newline`
- route output through `writeIP` so the default and `--no-newline` modes are easy to test
- update `README.md` to match the shipped CLI surface

## Checklist
- [x] Tests added or updated
- [x] `go vet ./...` passes locally
- [x] `go test ./...` passes locally
- [x] Documentation updated (if applicable)















