### PR TITLE
Clarify and test the IPv6-only -6 contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ myip -6
 2001:0db8:0000:0042:0000:8a2e:0370:7334
 ```
 
-If your machine doesn't have IPv6 address, fallbacks to IPv4.
+Note: `-6` uses only IPv6-capable resolvers and does not fall back to IPv4 if IPv6 is unavailable.
 
 ## Help
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -153,6 +153,16 @@ func writeIP(out io.Writer, ip string, noNewline bool) error {
 	return err
 }
 
+func selectRetrievables(ipv4 bool, ipv6 bool) []base.ScoredIPRetrievable {
+	if ipv4 {
+		return targets.IPv4Retrievables()
+	}
+	if ipv6 {
+		return targets.IPv6Retrievables()
+	}
+	return targets.IPRetrievables()
+}
+
 func main() {
 	opts, err := docopt.ParseDoc(usageText)
 	if err != nil {
@@ -162,14 +172,9 @@ func main() {
 		println(version)
 		return
 	}
-	var sir []base.ScoredIPRetrievable
-	if ipv4, _ := opts.Bool("--ipv4"); ipv4 {
-		sir = targets.IPv4Retrievables()
-	} else if ipv6, _ := opts.Bool("--ipv6"); ipv6 {
-		sir = targets.IPv6Retrievables()
-	} else {
-		sir = targets.IPRetrievables()
-	}
+	ipv4, _ := opts.Bool("--ipv4")
+	ipv6, _ := opts.Bool("--ipv6")
+	sir := selectRetrievables(ipv4, ipv6)
 	if verbose, _ := opts.Bool("--verbose"); verbose {
 		verboseMode = true
 	}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -4,11 +4,15 @@ import (
 	"bytes"
 	"math"
 	"net"
+	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/kitsuyui/myip/resolvers/base"
+	"github.com/kitsuyui/myip/resolvers/targets"
 )
 
 type fakeRetriever struct {
@@ -170,4 +174,41 @@ func TestWriteIP(t *testing.T) {
 			t.Fatalf("unexpected output: %q", got)
 		}
 	})
+}
+
+func TestSelectRetrievablesUsesIPv6OnlyTargetsWithoutIPv4Fallback(t *testing.T) {
+	selected := selectRetrievables(false, true)
+	ipv6Only := targets.IPv6Retrievables()
+	allTargets := targets.IPRetrievables()
+
+	if len(selected) == 0 {
+		t.Fatal("expected IPv6-capable targets")
+	}
+	if !slices.Equal(selected, ipv6Only) {
+		t.Fatal("expected --ipv6 selection to match IPv6-capable targets exactly")
+	}
+	if len(selected) >= len(allTargets) {
+		t.Fatal("expected --ipv6 selection to be narrower than the default target set")
+	}
+	for _, retrievable := range selected {
+		if !retrievable.IPv6 {
+			t.Fatalf("found non-IPv6 target in --ipv6 selection: %+v", retrievable)
+		}
+	}
+}
+
+func TestReadmeDocumentsIPv6OnlyContractWithoutFallback(t *testing.T) {
+	readmePath := filepath.Join("..", "README.md")
+	content, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	text := string(content)
+
+	if !strings.Contains(text, "does not fall back to IPv4") {
+		t.Fatal("README must document that -6 does not fall back to IPv4")
+	}
+	if strings.Contains(text, "fallbacks to IPv4") {
+		t.Fatal("README must not claim that -6 falls back to IPv4")
+	}
 }


### PR DESCRIPTION
## Summary

Clarify that `myip -6` uses only the IPv6-capable target set and add tests so the documented contract stays aligned with the CLI.

## Changes

- keep the README explicit that `-6` does not fall back to IPv4
- factor `--ipv4`/`--ipv6` target selection into a helper so the CLI contract is testable
- add tests covering IPv6-only selection and the README contract
- supersede https://github.com/kitsuyui/myip/pull/334, which can no longer be reopened after the branch was recreated

## Checklist

- [x] Tests added or updated
- [x] `go vet ./...` passes locally
- [x] `go test ./...` passes locally
- [x] Documentation updated (if applicable)
